### PR TITLE
Fix DBus issue

### DIFF
--- a/volti
+++ b/volti
@@ -19,15 +19,8 @@
 
 import os
 import sys
-
-try:
-    import dbus
-    import dbus._version
-    from dbus.mainloop.glib import DBusGMainLoop
-    assert dbus.version >= (0, 80, 0)
-except ImportError, AssertionError:
-    sys.stderr.write("This program needs dbus-python 0.80.0 or higher\nExiting\n")
-    sys.exit(1)
+import dbus
+from dbus.mainloop.glib import DBusGMainLoop
 
 if os.path.isdir(os.path.join(".","src")) and os.path.isfile(
         os.path.join(".","setup.py")):


### PR DESCRIPTION
Related to #53 and #54

As mentioned in #54, the check can be removed.
Using the plain imports allows the program to work as expected.