### PR TITLE
worked around indexing crash when getting volume of empty channel

### DIFF
--- a/src/volti/gtk2/mixer.py
+++ b/src/volti/gtk2/mixer.py
@@ -235,6 +235,8 @@ class Mixer(gtk.Window):
         ch, id = self.alsa_channels[card_index][channel]
         mixer = alsa.Mixer(ch, id, card_index)
         vol = mixer.getvolume()
+        if vol == None or len(vol) == 0:
+            return (0, 0)
         if len(vol) == 1:
             return (vol[0], vol[0])
         return (vol[0], vol[1])

--- a/src/volti/gtk3/mixer.py
+++ b/src/volti/gtk3/mixer.py
@@ -235,6 +235,8 @@ class Mixer(Gtk.Window):
         ch, id = self.alsa_channels[card_index][channel]
         mixer = alsa.Mixer(ch, id, card_index)
         vol = mixer.getvolume()
+        if vol == None or len(vol) == 0:
+            return (0, 0)
         if len(vol) == 1:
             return (vol[0], vol[0])
         return (vol[0], vol[1])


### PR DESCRIPTION
`get_volume()` in `mixer.py` is expected to always return a 2-tuple. This isn't great, but there it is. So we make sure to always return one.

Closes issue #67.